### PR TITLE
Docker update

### DIFF
--- a/.github/workflows/publish_image_to_dockerhub.yml
+++ b/.github/workflows/publish_image_to_dockerhub.yml
@@ -1,8 +1,11 @@
 name: Publish Docker image on DockerHub
 on: 
   push: 
+    branches:
+      - master
     paths: 
       - 'Dockerfile'
+    
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_image_to_dockerhub.yml
+++ b/.github/workflows/publish_image_to_dockerhub.yml
@@ -20,6 +20,14 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
       id: bump
+    - name: update Docker Compose
+      id: update_docker_compose
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git pull origin master
+        awk '{gsub("v[0-9]+[.]+.+", ${{ steps.bump.outputs.new_tag }}, $0); print}' docker-compose.yml
+        git commit -m "update Docker Compose" -a
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -33,14 +41,6 @@ jobs:
           - Rebuilt Docker image and published to DockerHub with new tag
         draft: false
         prerelease: false
-    - name: update Docker Compose
-      id: update_docker_compose
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git pull origin master
-        awk '{gsub("v[0-9]+[.]+.+", ${{ steps.bump.outputs.new_tag }}, $0); print}' docker-compose.yml
-        git commit -m "update Docker Compose" -a
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/.github/workflows/publish_image_to_dockerhub.yml
+++ b/.github/workflows/publish_image_to_dockerhub.yml
@@ -33,6 +33,14 @@ jobs:
           - Rebuilt Docker image and published to DockerHub with new tag
         draft: false
         prerelease: false
+    - name: update Docker Compose
+      id: update_docker_compose
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git pull origin master
+        awk '{gsub("v[0-9]+[.]+.+", ${{ steps.bump.outputs.new_tag }}, $0); print}' docker-compose.yml
+        git commit -m "update Docker Compose" -a
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) UBC-DSCI Development Team.
-FROM rocker/verse:4.0.0
+FROM rocker/verse:4.1.0
 
 RUN apt-get update --fix-missing \
 	&& apt-get install -y \
@@ -45,3 +45,45 @@ RUN apt-get update -qq && install2.r --error \
     tidymodels \
     reticulate \ 
     kknn
+    
+RUN Rscript -e "devtools::install_github('ttimbers/canlang@0.0.1')"
+
+# install LaTeX packages
+RUN tlmgr install amsmath \
+    latex-amsmath-dev \
+    fontspec \
+    tipa \
+    unicode-math \
+    xunicode \
+    kvoptions \
+    ltxcmds \
+    kvsetkeys \
+    etoolbox \
+    xcolor \
+    auxhook \
+    bigintcalc \
+    bitset \
+    etexcmds \
+    gettitlestring \
+    hycolor \
+    hyperref \
+    intcalc \
+    kvdefinekeys \
+    letltxmacro \
+    pdfescape \
+    refcount \
+    rerunfilecheck \
+    stringenc \
+    uniquecounter \
+    zapfding \
+    pdftexcmds \
+    infwarerr \
+    fancyvrb \
+    framed \
+    booktabs \
+    mdwtools \
+    grffile \
+    caption \
+    sourcecodepro \
+    amscls \
+    natbib

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is the source for the Introduction to Data Science textbook.
 > You can use this docker container to edit the files without RStudio using either vim or emacs. This can be done via:
 >
 > ```
-> docker-compose run --rm rstudio bash
+> docker-compose run --rm book-env bash
 > ```
 > 
 > or via:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ This is the source for the Introduction to Data Science textbook.
 
 > ### Usage without RStudio
 > You can use this docker container to edit the files without RStudio using either vim or emacs. This can be done via:
+>
+> ```
+> docker-compose run rstudio bash
+> ```
+> 
+> or via:
 > ```
 > docker run --rm -it -v $PWD:/introduction-to-datascience ubcdsci/intro-to-ds /bin/bash
 > ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This is the source for the Introduction to Data Science textbook.
     - type the following in terminal:
 
     ```
-    docker-compose up
+    docker-compose up -d
     ```
+    If you use this, then when you are done working, type `docker-compose down` to remove the dangling container.
+    
 
     > Alternatively, you can type:
     > ```
@@ -34,7 +36,7 @@ This is the source for the Introduction to Data Science textbook.
 > You can use this docker container to edit the files without RStudio using either vim or emacs. This can be done via:
 >
 > ```
-> docker-compose run rstudio bash
+> docker-compose run --rm rstudio bash
 > ```
 > 
 > or via:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ This is the source for the Introduction to Data Science textbook.
 2. Run RStudio inside the `ubcdsci/intro-to-ds` docker container:
     - in terminal, navigate to the root of this project repo
     - type the following in terminal:
+
     ```
-    docker run --rm -it -p 8787:8787 -v $PWD:/home/rstudio/introduction-to-datascience -e PASSWORD=password ubcdsci/intro-to-ds:v0.1.0
+    docker-compose up
     ```
+
+    > Alternatively, you can type:
+    > ```
+    > docker run --rm -it -p 8787:8787 -v $PWD:/home/rstudio/introduction-to-datascience -e PASSWORD=password ubcdsci/intro-to-ds:v0.1.0
+    > ```
+    
+    Next:
     - open a web browser and type [http://localhost:8787/](http://localhost:8787/)
     - for the username enter `rstudio` 
     - for the password enter `password` (or whatever you may have changed it to in the `docker run` command above)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  rstudio:
+    image: "ubcdsci/intro-to-ds:v0.6.0-47d5cbf"
+    ports:
+      - "8787:8787"
+    volumes:
+      - .:/home/rstudio/introduction-to-datascience
+    environment:
+      PASSWORD: password
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  rstudio:
+  book-env:
     image: "ubcdsci/intro-to-ds:v0.6.0-47d5cbf"
     ports:
       - "8787:8787"


### PR DESCRIPTION
Update to Dockerfile and actions that control its building.
- Only build Docker image when we push to master (makes cleaner image tags)
- Added canlang R package and LaTeX packages
- Added `docker-compose.yml` so that we can launch the RStudio container via `docker-compose up -d` to launch the rstudio web app, and `docker-compose run --rm rstudio bash` to run the container with bash as the entry point. This is less to type, and correctly specifies the ports, volume path and env vars.

Closes #71 and  #84.