### PR TITLE
Bibliography fixes: URLs and StatsCan

### DIFF
--- a/intro.Rmd
+++ b/intro.Rmd
@@ -607,7 +607,7 @@ n.o.s. with over 60,000 Canadian residents reporting it as their mother tongue.
 > Cree languages include the following categories: Cree n.o.s., Swampy Cree,
 > Plains Cree, Woods Cree, and a 'Cree not included elsewhere' category (which
 > includes Moose Cree, Northern East Cree and Southern East Cree)
-> [@language2018]. 
+> [@language2016]. 
 
 ### Putting it all together
 

--- a/pdf/index.Rmd
+++ b/pdf/index.Rmd
@@ -7,7 +7,7 @@ documentclass: krantz
 classoption:
   - krantz2
 bibliography: [references.bib]
-biblio-style: apalike
+biblio-style: plainnat
 link-citations: yes
 colorlinks: yes
 lot: yes

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,6 +1,7 @@
 \usepackage{booktabs}
 \usepackage{amsthm}
 \usepackage{makeidx}
+\usepackage{url}
 \makeindex
 \makeatletter
 \def\thm@space@setup{%

--- a/references.bib
+++ b/references.bib
@@ -26,8 +26,7 @@
   volume={347},
   number={6228},
   pages={1314--1315},
-  year={2015},
-  publisher={American Association for the Advancement of Science}
+  year={2015}
 }
 
 @book{peng2015art,

--- a/references.bib
+++ b/references.bib
@@ -10,13 +10,15 @@
 @misc{cancensus2016,
   author = {{Statistics Canada}},
   title = {Population Census},
-  year = {2016}
+  year = {2016},
+  url = {https://www12.statcan.gc.ca/census-recensement/2016/dp-pd/index-eng.cfm}
 }
 
-@misc{language2018,
+@misc{language2016,
   author = {{Statistics Canada}},
-  title = {Aboriginal languages in Canada},
-  year = {2018},
+  title = {The Aboriginal languages of First Nations people, M\'etis and Inuit},
+  year = {2016},
+  url = {https://www12.statcan.gc.ca/census-recensement/2016/as-sa/98-200-x/2016022/98-200-x2016022-eng.cfm}
 }
 
 @article{leek2015question,


### PR DESCRIPTION
This PR makes it so that URLs properly render in `@misc` biblio entries in the PDF copy (uses `plainnat`). I tried to use the `apacite.bst` style, but that created some latex errors.

 The PR also provides URLs for StatsCan references.

Resolves #304 and #305 