### PR TITLE
Patch plotly pdf

### DIFF
--- a/build_html.sh
+++ b/build_html.sh
@@ -1,2 +1,2 @@
 # Script to generate HTML book
-docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.15.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience; Rscript _build_html.r"
+docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.16.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience; Rscript _build_html.r"

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -22,7 +22,7 @@ cp -r data/ pdf/data
 cp -r img/ pdf/img
 
 # Build the book with bookdown
-docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.15.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience/pdf; Rscript _build_pdf.r"
+docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.16.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience/pdf; Rscript _build_pdf.r"
 
 # clean files in pdf dir
 rm -rf pdf/references.bib

--- a/classification1.Rmd
+++ b/classification1.Rmd
@@ -569,7 +569,7 @@ Based on $K=5$ nearest neighbors with these three predictors we would classify t
 Figure \@ref(fig:05-more) shows what the data look like when we visualize them 
 as a 3-dimensional scatter with lines from the new observation to its five nearest neighbors.
 
-```{r 05-more, echo = FALSE, message = FALSE, fig.cap = "3D scatter plot of the standardized symmetry, concavity, and perimeter variables. Note that in general we recommend against using 3D visualizations; here we show the data in 3D only to illustrate what higher dimensions and nearest neighbors look like, for learning purposes.", fig.retina=2, out.width="80%"}
+```{r 05-more, echo = FALSE, message = FALSE, fig.cap = "3D scatter plot of the standardized symmetry, concavity, and perimeter variables. Note that in general we recommend against using 3D visualizations; here we show the data in 3D only to illustrate what higher dimensions and nearest neighbors look like, for learning purposes.", fig.retina=2, out.width="100%"}
 attrs <- c("Perimeter", "Concavity", "Symmetry")
 
 # create new scaled obs and get NNs

--- a/classification1.Rmd
+++ b/classification1.Rmd
@@ -10,6 +10,7 @@ knitr::opts_chunk$set(echo = TRUE,
 options(knitr.table.format = function() {
   if (knitr::is_latex_output()) 'latex' else 'pandoc'
 })
+reticulate::use_miniconda('r-reticulate')
 ```
 
 ## Overview 
@@ -598,7 +599,7 @@ plot_3d <- scaled_cancer_3 |>
             z = ~Symmetry,
             color = ~Class,
             opacity = 0.4,
-            size = 150,
+            size = 5,
             colors = c("orange2", "steelblue2", "red"), 
             symbol = ~Class, symbols = c('circle','circle','diamond'))
 
@@ -637,6 +638,9 @@ plot_3d <- plot_3d  %>%
 if(!is_latex_output()){  
   plot_3d
 } else {
+  scene = list(camera = list(eye = list(x=2, y=2, z = 1.5)))
+  plot_3d <- plot_3d  %>% layout(scene = scene)
+  save_image(plot_3d, "img/plot3d_knn_classification.png", scale = 10)
   knitr::include_graphics("img/plot3d_knn_classification.png")
 }
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   book-env:
-    image: ubcdsci/intro-to-ds:v0.12.0
+    image: ubcdsci/intro-to-ds:v0.16.0
     ports:
       - "8787:8787"
     volumes:
@@ -10,5 +10,5 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 5G
       

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -760,7 +760,7 @@ Figure \@ref(fig:07-knn-mult-viz) visualizes the model's predictions overlaid on
 time the predictions are a surface in 3D space, instead of a line in 2D space, as we have 2
 predictors instead of 1.  
 
-```{r 07-knn-mult-viz, echo = FALSE, message = FALSE, warning = FALSE, fig.cap = "KNN regression model’s predictions represented as a surface in 3D space overlaid on top of the data using three predictors (price, house size, and the number of bedrooms). Note that in general we recommend against using 3D visualizations; here we use a 3D visualization only to illustrate what the surface of predictions looks like for learning purposes.", out.width="80%"}
+```{r 07-knn-mult-viz, echo = FALSE, message = FALSE, warning = FALSE, fig.cap = "KNN regression model’s predictions represented as a surface in 3D space overlaid on top of the data using three predictors (price, house size, and the number of bedrooms). Note that in general we recommend against using 3D visualizations; here we use a 3D visualization only to illustrate what the surface of predictions looks like for learning purposes.", out.width="100%"}
 xvals <- seq(from = min(sacramento_train$sqft), 
              to = max(sacramento_train$sqft), 
              length = 50)
@@ -781,12 +781,12 @@ plot_3d <- plot_ly() |>
     x = ~sqft,
     y = ~beds,
     z = ~price,
-    marker = list(size = 5, opacity = 0.4, color = "red")
+    marker = list(size = 2, opacity = 0.4, color = "red")
   ) |>
   layout(scene = list(
-    xaxis = list(title = "House size (square feet)"),
+    xaxis = list(title = "Size (sq ft)"),
     zaxis = list(title = "Price (USD)"),
-    yaxis = list(title = "Number of bedrooms")
+    yaxis = list(title = "Bedrooms")
   )) |>
   add_surface(
     x = ~xvals,
@@ -798,8 +798,8 @@ plot_3d <- plot_ly() |>
 if(!is_latex_output()){  
   plot_3d
 } else {
-  scene = list(camera = list(eye = list(x=2, y=2, z = 1.5)))
-  plot_3d <- plot_3d  %>% layout(scene = scene)
+  scene = list(camera = list(eye = list(x = -2.1, y = -2.2, z = 0.75)))
+  plot_3d <- plot_3d  |> layout(scene = scene)
   save_image(plot_3d, "img/plot3d_knn_regression.png", scale = 10)
   knitr::include_graphics("img/plot3d_knn_regression.png")
 }

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -5,6 +5,7 @@ library(knitr)
 library(plotly)
 
 knitr::opts_chunk$set(fig.align = "center")
+reticulate::use_miniconda('r-reticulate')
 ```
 
 ## Overview 
@@ -797,6 +798,9 @@ plot_3d <- plot_ly() |>
 if(!is_latex_output()){  
   plot_3d
 } else {
+  scene = list(camera = list(eye = list(x=2, y=2, z = 1.5)))
+  plot_3d <- plot_3d  %>% layout(scene = scene)
+  save_image(plot_3d, "img/plot3d_knn_regression.png", scale = 10)
   knitr::include_graphics("img/plot3d_knn_regression.png")
 }
 ```

--- a/regression2.Rmd
+++ b/regression2.Rmd
@@ -5,6 +5,7 @@ library(knitr)
 library(plotly)
 
 knitr::opts_chunk$set(fig.align = "center")
+reticulate::use_miniconda('r-reticulate')
 ```
 
 ## Overview 
@@ -491,6 +492,9 @@ plot_3d <- plot_ly() |>
 if(!is_latex_output()){  
   plot_3d
 } else {
+  scene = list(camera = list(eye = list(x=2, y=2, z = 1.5)))
+  plot_3d <- plot_3d  %>% layout(scene = scene)
+  save_image(plot_3d, "img/plot3d_linear_regression.png", scale = 10)
   knitr::include_graphics("img/plot3d_linear_regression.png")
 }
 ```

--- a/regression2.Rmd
+++ b/regression2.Rmd
@@ -454,7 +454,7 @@ is `r format(round(lm_mult_test_results %>% filter(.metric == 'rmse') %>% pull(.
 In the case of two predictors, we can plot the predictions made by our linear regression creates a *plane* of best fit, as
 shown in Figure \@ref(fig:08-3DlinReg).
 
-```{r 08-3DlinReg, echo = FALSE, message = FALSE, warning = FALSE, fig.cap = "Linear regression plane of best fit overlaid on top of the data (using price, house size, and number of bedrooms as predictors). Note that in general we recommend against using 3D visualizations; here we use a 3D visualization only to illustrate what the regression plane looks like for learning purposes.", out.width="80%"}
+```{r 08-3DlinReg, echo = FALSE, message = FALSE, warning = FALSE, fig.cap = "Linear regression plane of best fit overlaid on top of the data (using price, house size, and number of bedrooms as predictors). Note that in general we recommend against using 3D visualizations; here we use a 3D visualization only to illustrate what the regression plane looks like for learning purposes.", out.width="100%"}
 xvals <- seq(from = min(sacramento_train$sqft), 
              to = max(sacramento_train$sqft), 
              length = 50)
@@ -475,12 +475,12 @@ plot_3d <- plot_ly() |>
     x = ~sqft,
     y = ~beds,
     z = ~price,
-    marker = list(size = 5, opacity = 0.4, color = "red")
+    marker = list(size = 2, opacity = 0.4, color = "red")
   ) |>
   layout(scene = list(
-    xaxis = list(title = "House size (square feet)"),
+    xaxis = list(title = "Size (sq ft)"),
     zaxis = list(title = "Price (USD)"),
-    yaxis = list(title = "Number of bedrooms")
+    yaxis = list(title = "Bedrooms")
   )) |>
   add_surface(
     x = ~xvals,
@@ -492,7 +492,7 @@ plot_3d <- plot_ly() |>
 if(!is_latex_output()){  
   plot_3d
 } else {
-  scene = list(camera = list(eye = list(x=2, y=2, z = 1.5)))
+  scene = list(camera = list(eye = list(x = -2.1, y = -2.2, z = 0.75)))
   plot_3d <- plot_3d  %>% layout(scene = scene)
   save_image(plot_3d, "img/plot3d_linear_regression.png", scale = 10)
   knitr::include_graphics("img/plot3d_linear_regression.png")


### PR DESCRIPTION
This PR reproducibly generates high resolution static plotly figures for the pdf. It depends on the `reticulate` + the `python-kaleido` package - which have been added to the `Dockerfile`. This means we need to now use the Docker image with the version `v0.16.0` now. I have updated the build scripts to reflect this.

Note: I had to downsize the point size in the plotly figures to make them work for PDF. If they are now too smal for html (they are smaller, but I am not sure if it is too small) then we need to have the if statement also conditionally control the point size.

Closes:

- #330