### PR TITLE
remove infer and add scales

### DIFF
--- a/setup.Rmd
+++ b/setup.Rmd
@@ -155,11 +155,11 @@ conda install -c conda-forge -y \
   r-cowplot \
   r-ggally \
   r-gridextra \
-  r-infer \
   r-kknn \
   r-rodbc \
   r-rpostgres \
   r-rsqlite \
+  r-scales \
   r-testthat \
   r-tidymodels \
   r-tidyverse \


### PR DESCRIPTION
- scales is used in textbook and worksheets
- infer is now installed by tidymodels