### PR TITLE
Copyediting round 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN Rscript -e "reticulate::install_miniconda()"
 RUN Rscript -e "reticulate::conda_install('r-reticulate', 'python-kaleido')"
 RUN Rscript -e "reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly')"
 
+RUN Rscript -e "devtools::install_github('mountainMath/cancensus@5a5d61759d477986d40dd87fa9a6532ff6037efe')"
 RUN Rscript -e "devtools::install_github('ttimbers/canlang@0.0.1')"
 
 # install LaTeX packages
@@ -100,3 +101,9 @@ RUN tlmgr install amsmath \
 RUN sed -i 's/256MiB/4GiB/' /etc/ImageMagick-6/policy.xml
 RUN sed -i 's/512MiB/4GiB/' /etc/ImageMagick-6/policy.xml
 RUN sed -i 's/1GiB/4GiB/' /etc/ImageMagick-6/policy.xml
+
+# install version of tinytex with fixed index double-compile (no release for this yet, so install from commit hash)
+RUN Rscript -e "remove.packages('xfun')"
+RUN Rscript -e "devtools::install_github('yihui/xfun@v0.29')"
+RUN Rscript -e "remove.packages('tinytex')"
+RUN Rscript -e "devtools::install_github('yihui/tinytex@5d211d43944d322fca49e5f0d97f34b9c46ff9ab')"

--- a/acknowledgements.Rmd
+++ b/acknowledgements.Rmd
@@ -19,7 +19,7 @@ Rohan Alexander, Isabella Ghement, Virgilio Gómez Rubio, Albert Kim, Adam Loy, 
 The book was improved substantially by their insights.
 We would like to give special thanks to Jim Zidek
 for his support and encouragement throughout the process, and to
-Roger Peng for graciously offering to write the foreword.
+Roger Peng for graciously offering to write the Foreword.
 
 Finally, we owe a debt of gratitude to all of the students of DSCI 100 over the past
 few years. They provided invaluable feedback on the book and worksheets; 

--- a/build_html.sh
+++ b/build_html.sh
@@ -1,2 +1,2 @@
 # Script to generate HTML book
-docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.21.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience; Rscript _build_html.r"
+docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.22.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience; Rscript _build_html.r"

--- a/build_pdf.sh
+++ b/build_pdf.sh
@@ -25,7 +25,7 @@ cp -r data/ pdf/data
 cp -r img/ pdf/img
 
 # Build the book with bookdown
-docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.21.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience/pdf; Rscript _build_pdf.r"
+docker run --rm -m 5g -v $(pwd):/home/rstudio/introduction-to-datascience ubcdsci/intro-to-ds:v0.22.0 /bin/bash -c "cd /home/rstudio/introduction-to-datascience/pdf; Rscript _build_pdf.r"
 
 # clean files in pdf dir
 rm -rf pdf/references.bib

--- a/classification1.Rmd
+++ b/classification1.Rmd
@@ -1415,9 +1415,14 @@ wkflw_plot
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_classification1/worksheet_classification1.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Classification I: training and predicting'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
+
+

--- a/classification1.Rmd
+++ b/classification1.Rmd
@@ -1421,7 +1421,7 @@ in the "Classification I: training and predicting" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/classification1.Rmd
+++ b/classification1.Rmd
@@ -1417,9 +1417,9 @@ wkflw_plot
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Classification I: training and predicting'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Classification I: training and predicting" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/classification2.Rmd
+++ b/classification2.Rmd
@@ -1386,12 +1386,17 @@ fwd_sel_accuracies_plot
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_classification2/worksheet_classification2.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Classification II: evaluation and tuning'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
+
+
 
 ## Additional resources
 - The [`tidymodels` website](https://tidymodels.org/packages) is an excellent

--- a/classification2.Rmd
+++ b/classification2.Rmd
@@ -1388,9 +1388,9 @@ fwd_sel_accuracies_plot
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Classification II: evaluation and tuning'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Classification II: evaluation and tuning" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/classification2.Rmd
+++ b/classification2.Rmd
@@ -1392,7 +1392,7 @@ in the "Classification II: evaluation and tuning" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/clustering.Rmd
+++ b/clustering.Rmd
@@ -1103,12 +1103,15 @@ elbow_plot
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_clustering/worksheet_clustering.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Clustering'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
 
 ## Additional resources
 - Chapter 10 of *An Introduction to Statistical

--- a/clustering.Rmd
+++ b/clustering.Rmd
@@ -1105,9 +1105,9 @@ elbow_plot
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Clustering'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Clustering" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/clustering.Rmd
+++ b/clustering.Rmd
@@ -1109,7 +1109,7 @@ in the "Clustering" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   book-env:
-    image: ubcdsci/intro-to-ds:v0.21.0
+    image: ubcdsci/intro-to-ds:v0.22.0
     ports:
       - "8787:8787"
     volumes:

--- a/inference.Rmd
+++ b/inference.Rmd
@@ -1169,14 +1169,15 @@ statistical techniques you may learn about in the future!
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the two accompanying worksheets
-([first worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_inference1/worksheet_inference1.ipynb) 
-and [second worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_inference2/worksheet_inference2.ipynb)).
-The worksheets try to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the two ``Statistical inference'' rows.
+You can launch an interactive version of each worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of each worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheets and run them on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
 
 ## Additional resources
 

--- a/inference.Rmd
+++ b/inference.Rmd
@@ -1175,7 +1175,7 @@ in the two "Statistical inference" rows.
 You can launch an interactive version of each worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of each worksheet by clicking "view worksheet."
 If you instead decide to download the worksheets and run them on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/inference.Rmd
+++ b/inference.Rmd
@@ -1171,9 +1171,9 @@ statistical techniques you may learn about in the future!
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the two ``Statistical inference'' rows.
-You can launch an interactive version of each worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of each worksheet by clicking ``view worksheet''.
+in the two "Statistical inference" rows.
+You can launch an interactive version of each worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of each worksheet by clicking "view worksheet."
 If you instead decide to download the worksheets and run them on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -706,9 +706,9 @@ knitr::include_graphics("img/help-filter.png")
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``R and the tidyverse'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "R and the tidyverse" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -710,6 +710,6 @@ in the "R and the tidyverse" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -528,7 +528,7 @@ image_read("img/ggplot_function.jpeg") |>
   image_crop("1625x1900")
 ```
 
-```{r barplot-mother-tongue, fig.width=5, fig.height=3, warning=FALSE, fig.cap = "Bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue."}
+```{r barplot-mother-tongue, fig.width=5, fig.height=3, warning=FALSE, fig.cap = "Bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue. Note that this visualization is not done yet; there are still improvements to be made."}
 ggplot(ten_lang, aes(x = language, y = mother_tongue)) +
   geom_bar(stat = "identity")
 ```
@@ -567,7 +567,7 @@ words (e.g. `"Mother Tongue (Number of Canadian Residents)"`) as arguments to
 layers to format the plot further, and we will explore these in Chapter
 \@ref(viz).
 
-(ref:barplot-mother-tongue-labs) Bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue with x and y labels.
+(ref:barplot-mother-tongue-labs) Bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue with x and y labels. Note that this visualization is not done yet; there are still improvements to be made.
 
 ```{r barplot-mother-tongue-labs, fig.width=5, fig.height=3.6, warning=FALSE, fig.cap = "(ref:barplot-mother-tongue-labs)", fig.pos = "H", out.extra=""}
 ggplot(ten_lang, aes(x = language, y = mother_tongue)) +
@@ -583,7 +583,7 @@ currently making it difficult to read the different language names.
 One solution is to rotate the plot such that the bars are horizontal rather than vertical.
 To accomplish this, we will swap the x and y coordinate axes:
 
-```{r barplot-mother-tongue-flipped, fig.width=5, fig.height=3, fig.pos = "H", out.extra="", warning=FALSE, fig.cap = "Horizontal bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue."}
+```{r barplot-mother-tongue-flipped, fig.width=5, fig.height=3, fig.pos = "H", out.extra="", warning=FALSE, fig.cap = "Horizontal bar plot of the ten Aboriginal languages most often reported by Canadian residents as their mother tongue. There are no more serious issues with this visualization, but it could be refined further."}
 ggplot(ten_lang, aes(x = mother_tongue, y = language)) +
   geom_bar(stat = "identity") +
   xlab("Mother Tongue (Number of Canadian Residents)") +

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -704,9 +704,12 @@ knitr::include_graphics("img/help-filter.png")
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_intro/worksheet_intro.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``R and the tidyverse'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.

--- a/pdf/latex/before_body.tex
+++ b/pdf/latex/before_body.tex
@@ -18,5 +18,7 @@ To mom and dad, thank you for all your love and support.
 %\includegraphics{images/dedication.pdf}
 \end{center}
 
+\cleardoublepage\newpage\thispagestyle{empty}\null
+
 \setlength{\abovedisplayskip}{-5pt}
 \setlength{\abovedisplayshortskip}{-5pt}

--- a/preface-text.Rmd
+++ b/preface-text.Rmd
@@ -53,11 +53,11 @@ to help you practice the concepts you will learn. We strongly recommend that you
 work through the worksheet when you finish reading each chapter 
 before moving on to the next chapter. All of the worksheets
 are available at 
-[https://ubc-dsci.github.io/data-science-a-first-intro-worksheets](https://ubc-dsci.github.io/data-science-a-first-intro-worksheets);
+[https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme);
 the "Exercises" section at the end of each chapter points you to the right worksheet for that chapter.
-The worksheets are designed to provide automated feedback and help guide you through the problems.
-To make sure that functionality works as intended, make sure to follow the setup directions 
-in Chapter \@ref(move-to-your-own-machine) regarding downloading the worksheets.
-
-
-
+For each worksheet, you can either launch an interactive version of the worksheet in your browser by clicking the "launch binder" button,
+or preview a non-interactive version of the worksheet by clicking "view worksheet."
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.

--- a/reading.Rmd
+++ b/reading.Rmd
@@ -1243,9 +1243,9 @@ data you are requesting and how frequently you are making requests.
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Reading in data locally and from the web'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Reading in data locally and from the web" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/reading.Rmd
+++ b/reading.Rmd
@@ -994,7 +994,6 @@ The selector gadget returns them to us as a comma-separated list (here
 R if we are using more than one CSS selector.
 
 **Stop! Are you allowed to scrape that website?**
-
 *Before* scraping \index{web scraping!permission} data from the web, you should always check whether or not
 you are *allowed* to scrape it! There are two documents that are important
 for this: the `robots.txt` file and the Terms of Service

--- a/reading.Rmd
+++ b/reading.Rmd
@@ -1241,12 +1241,15 @@ data you are requesting and how frequently you are making requests.
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_reading/worksheet_reading.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Reading in data locally and from the web'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
 
 ## Additional resources
 - The [`readr` documentation](https://readr.tidyverse.org/) 

--- a/reading.Rmd
+++ b/reading.Rmd
@@ -971,8 +971,8 @@ knitr::include_graphics("img/sg1.png")
 ```
 
 If we then click the size of an apartment listing, SelectorGadget shows us
-the `span` selector, and highlights much of the page; this indicates that the
-`span` selector is not specific enough to just capture apartment sizes (Figure \@ref(fig:sg3)). 
+the `span` selector, and highlights many of the lines on the page; this indicates that the
+`span` selector is not specific enough to capture only apartment sizes (Figure \@ref(fig:sg3)). 
 
 ```{r sg3, echo = FALSE, message = FALSE, warning = FALSE, fig.cap = "Using the SelectorGadget on a Craigslist webpage to obtain a CCS selector useful for obtaining apartment sizes.", fig.retina = 2, out.width="100%"}
 knitr::include_graphics("img/sg3.png")
@@ -1247,7 +1247,7 @@ in the "Reading in data locally and from the web" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -93,16 +93,18 @@ is that we are now predicting numerical variables instead of categorical variabl
 
 \newpage
 
-> **Note:** You can usually tell whether a \index{categorical variable}\index{numerical variable}
-> variable is numerical or categorical&mdash;and therefore whether you
-> need to perform regression or classification&mdash;by taking two response variables X and Y from your
-> data, and asking the question, "is response variable X *more* than response variable Y?"
-> If the variable is categorical, the question will make no sense (Is blue more than red?
-> Is benign more than malignant?). If the variable is numerical, it will make sense
-> (Is 1.5 hours more than 2.25 hours? Is \$500,000 more than \$400,000?).
-> Be careful when applying this heuristic, though: sometimes categorical variables will be encoded as
-> numbers in your data (e.g., "1" represents "benign", and "0" represents "malignant"). In these cases
-> you have to ask the question about the *meaning* of the labels ("benign" and "malignant"), not their values ("1" and "0"). 
+> **Note:** You can usually tell whether a \index{categorical variable}\index{numerical variable} variable is numerical or
+> categorical&mdash;and therefore whether you need to perform regression or
+> classification&mdash;by taking two response variables X and Y from your data,
+> and asking the question, "is response variable X *more* than response
+> variable Y?" If the variable is categorical, the question will make no sense.
+> (Is blue more than red?  Is benign more than malignant?) If the variable is
+> numerical, it will make sense. (Is 1.5 hours more than 2.25 hours? Is
+> \$500,000 more than \$400,000?) Be careful when applying this heuristic,
+> though: sometimes categorical variables will be encoded as numbers in your
+> data (e.g., "1" represents "benign", and "0" represents "malignant"). In
+> these cases you have to ask the question about the *meaning* of the labels
+> ("benign" and "malignant"), not their values ("1" and "0"). 
 
 ## Exploring a data set
 

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -876,7 +876,7 @@ in the "Regression I: K-nearest neighbors" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -93,7 +93,7 @@ is that we are now predicting numerical variables instead of categorical variabl
 
 \newpage
 
-> **Note:** You can usually tell whether a \index{categorical variable}\index{numerical variable} variable is numerical or
+> **Note:** You can usually tell whether a\index{categorical variable}\index{numerical variable} variable is numerical or
 > categorical&mdash;and therefore whether you need to perform regression or
 > classification&mdash;by taking two response variables X and Y from your data,
 > and asking the question, "is response variable X *more* than response

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -870,9 +870,14 @@ regression has both strengths and weaknesses. Some are listed here:
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_regression1/worksheet_regression1.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Regression I: K-nearest neighbors'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
+
+

--- a/regression1.Rmd
+++ b/regression1.Rmd
@@ -872,9 +872,9 @@ regression has both strengths and weaknesses. Some are listed here:
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Regression I: K-nearest neighbors'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Regression I: K-nearest neighbors" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/regression2.Rmd
+++ b/regression2.Rmd
@@ -901,7 +901,7 @@ in the "Regression II: linear regression" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/regression2.Rmd
+++ b/regression2.Rmd
@@ -895,12 +895,17 @@ that will serve you well when moving to more advanced books on the topic.
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_regression2/worksheet_regression2.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Regression II: linear regression'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
+
+
 
 ## Additional resources
 - The [`tidymodels` website](https://tidymodels.org/packages) is an excellent

--- a/regression2.Rmd
+++ b/regression2.Rmd
@@ -897,9 +897,9 @@ that will serve you well when moving to more advanced books on the topic.
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Regression II: linear regression'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Regression II: linear regression" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/setup.Rmd
+++ b/setup.Rmd
@@ -128,7 +128,7 @@ and to running `conda init`, which makes `conda` available from the terminal.
 
 ### JupyterLab
 
-With miniconda set up, we can now install JupyterLab \index{JupyterLab!installation} and the Jupyter Git \index{git!Jupyter extension} extension. 
+With miniconda set up, we can now install JupyterLab \index{JupyterLab installation} and the Jupyter Git \index{git!Jupyter extension} extension. 
 Type the following into the Anaconda Prompt (Windows) or the terminal (MacOS and Ubuntu) and press enter:
 
 ```
@@ -157,7 +157,7 @@ jupyter labextension install @techrah/text-shortcuts
 
 ### R, R packages, and the IRkernel 
 
-To have the software \index{R!installation} used in this book available to you in JupyterLab, 
+To have the software \index{R installation} used in this book available to you in JupyterLab, 
 you will need to install the R programming language,
 several R packages,
 and the \index{kernel!installation} IRkernel.

--- a/version-control.Rmd
+++ b/version-control.Rmd
@@ -553,7 +553,9 @@ copy that knows where it was obtained from so that it knows where to send/receiv
 new committed edits. In order to do this, first copy the URL from the HTTPS tab 
 of the Code drop-down menu on GitHub (Figure \@ref(fig:clone-02)).
 
-```{r clone-02, fig.pos = "H", out.extra="", fig.cap = 'The green ``Code'' drop-down menu contains the remote address (URL) corresponding to the location of the remote GitHub repository.', fig.retina = 2, out.width="100%"}
+(ref:clone-02) The green "Code" drop-down menu contains the remote address (URL) corresponding to the location of the remote GitHub repository.
+
+```{r clone-02, fig.pos = "H", out.extra="", fig.cap = '(ref:clone-02)', fig.retina = 2, out.width="100%"}
 image_read("img/version_control/clone_02.png") |>
   image_crop("3584x1050")
 ```

--- a/version-control.Rmd
+++ b/version-control.Rmd
@@ -943,9 +943,9 @@ image_read("img/version_control/issue_06.png") |>
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Collaboration with version control'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Collaboration with version control" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/version-control.Rmd
+++ b/version-control.Rmd
@@ -941,12 +941,15 @@ image_read("img/version_control/issue_06.png") |>
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_version_control/worksheet_version_control.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Collaboration with version control'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
 
 ## Additional resources {#vc-add-res}
 

--- a/version-control.Rmd
+++ b/version-control.Rmd
@@ -947,7 +947,7 @@ in the "Collaboration with version control" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/version-control.Rmd
+++ b/version-control.Rmd
@@ -553,7 +553,7 @@ copy that knows where it was obtained from so that it knows where to send/receiv
 new committed edits. In order to do this, first copy the URL from the HTTPS tab 
 of the Code drop-down menu on GitHub (Figure \@ref(fig:clone-02)).
 
-```{r clone-02, fig.pos = "H", out.extra="", fig.cap = 'The green "Code" drop-down menu contains the remote address (URL) corresponding to the location of the remote GitHub repository.', fig.retina = 2, out.width="100%"}
+```{r clone-02, fig.pos = "H", out.extra="", fig.cap = 'The green ``Code'' drop-down menu contains the remote address (URL) corresponding to the location of the remote GitHub repository.', fig.retina = 2, out.width="100%"}
 image_read("img/version_control/clone_02.png") |>
   image_crop("3584x1050")
 ```

--- a/viz.Rmd
+++ b/viz.Rmd
@@ -1515,12 +1515,15 @@ knitr::include_graphics("img/png-vs-svg.png")
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_viz/worksheet_viz.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Effective data visualization'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
 
 ## Additional resources
 - The [`ggplot2` R package page](https://ggplot2.tidyverse.org) [@ggplot] is

--- a/viz.Rmd
+++ b/viz.Rmd
@@ -1517,9 +1517,9 @@ knitr::include_graphics("img/png-vs-svg.png")
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Effective data visualization'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Effective data visualization" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback

--- a/viz.Rmd
+++ b/viz.Rmd
@@ -1521,7 +1521,7 @@ in the "Effective data visualization" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/wrangling.Rmd
+++ b/wrangling.Rmd
@@ -1621,7 +1621,7 @@ in the "Cleaning and wrangling data" row.
 You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
 You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup  
+make sure to follow the instructions for computer setup
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.
 

--- a/wrangling.Rmd
+++ b/wrangling.Rmd
@@ -1615,12 +1615,17 @@ Table: (#tab:summary-functions-table) Summary of wrangling functions
 ## Exercises
 
 Practice exercises for the material covered in this chapter 
-can be found in the accompanying [worksheet](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/blob/main/worksheet_wrangling/worksheet_wrangling.ipynb).
-The worksheet tries to provide automated feedback 
-and help guide you through the problems. 
-To make sure this functionality works as intended, 
-please follow the instructions for computer setup needed to run the worksheets 
-found in Chapter \@ref(move-to-your-own-machine).
+can be found in the accompanying 
+[worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
+in the ``Cleaning and wrangling data'' row.
+You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
+You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+If you instead decide to download the worksheet and run it on your own machine,
+make sure to follow the instructions for computer setup  
+found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback
+and guidance that the worksheets provide will function as intended.
+
+
 
 ## Additional resources 
 

--- a/wrangling.Rmd
+++ b/wrangling.Rmd
@@ -1617,9 +1617,9 @@ Table: (#tab:summary-functions-table) Summary of wrangling functions
 Practice exercises for the material covered in this chapter 
 can be found in the accompanying 
 [worksheets repository](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme)
-in the ``Cleaning and wrangling data'' row.
-You can launch an interactive version of the worksheet in your browser by clicking the ``launch binder'' button.
-You can also preview a non-interactive version of the worksheet by clicking ``view worksheet''.
+in the "Cleaning and wrangling data" row.
+You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
+You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
 If you instead decide to download the worksheet and run it on your own machine,
 make sure to follow the instructions for computer setup  
 found in Chapter \@ref(move-to-your-own-machine). This will ensure that the automated feedback


### PR DESCRIPTION
This PR closes:
- #422 (various fixes)
- #314  (fixed by forcing `tinytex` to use the current master branch in the repo, which has the fix for index 2x compile. I also had to use the latest `xfun`, which `tinytex` seems to depend on.)
- #421 (edited the blurb and link to point to the worksheets repo readme)

Note 0: the edits should be self-explanatory except one in `reading.Rmd`, where it looks like I just changed a few words for no reason. That was to force the "**Stop! Are you allowed....**" onto the next page.

Note 1: right now the container is at `v0.22.0` on `master` (and dockerhub), which fixes the index hyperref issue. It's also `v0.22.0` in the build scripts on this branch.

But because I originally edited the dockerfile on this branch (before I realized I had to do it on master), I eventually made the same edit directly on master and merged into this branch. So I suspect when we merge this PR into dev and then master, it might bump the docker container again. In that case you're safe to edit `build_pdf.sh` and `build_html.sh` to use container `v0.23.0` -- nothing will change between `v0.22.0` and `v0.23.0`.

Note 2: The docker image would not build unless I specified an updated version of the `cancensus` package (which `canlang` depends on). I had to pin cancensus to a git commit hash. So **please double-check that nothing broke anywhere we use `canlang`.**

Note 3: I was unable to get a single blank page between the dedications and the TOC. I could only get either 2 or 0. I believe LaTeX forces 2 blank pages here because the TOC has to start on an odd page. **We should notify Michele of this, but I don't think we need to do anything ourselves**

Note 4: You'll notice in the Exercises blurbs that I point to https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets#readme (instead of https://ubc-dsci.github.io/data-science-a-first-intro-worksheets/ ). The "view worksheets" links don't work on the github.io site; they download the worksheet instead of previewing it in github. I also fixed the link and blurb text at the end of the preface where we mention worksheets.

Note 5: We should also tell Michele directly that Fig 1.7 and 1.8 are meant to have broken x axis labels (in addition to me editing the caption), because that was also flagged in the first copyediting pass.