### PR TITLE
Correct parameter name in `facet_grid`

### DIFF
--- a/viz.Rmd
+++ b/viz.Rmd
@@ -1147,8 +1147,8 @@ into subplots, and how to split them (i.e., into rows or columns).
 If the plot is to be split horizontally, into rows, 
 then the `rows` argument is used.
 If the plot is to be split vertically, into columns, 
-then the `columns` argument is used.
-Both the `rows` and `columns` arguments take the column names on which to split the data when creating the subplots. 
+then the `cols` argument is used.
+Both the `rows` and `cols` arguments take the column names on which to split the data when creating the subplots. 
 Note that the column names must be surrounded by the `vars` function.
 This function allows the column names to be correctly evaluated 
 in the context of the data frame.


### PR DESCRIPTION
The parameter used for faceting into columns is called `cols` rather than `columns` https://ggplot2.tidyverse.org/reference/facet_grid.html. I noticed this when going through the slides for DSCI-100. 