### PR TITLE
Remove binder suggestion

### DIFF
--- a/source/classification1.Rmd
+++ b/source/classification1.Rmd
@@ -1500,15 +1500,12 @@ wkflw_plot
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Classification I: training and predicting" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
-
-
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Classification I: training and predicting" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.

--- a/source/classification2.Rmd
+++ b/source/classification2.Rmd
@@ -1678,17 +1678,15 @@ fwd_sel_accuracies_plot
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Classification II: evaluation and tuning" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
-
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Classification II: evaluation and tuning" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
 
 
 ## Additional resources

--- a/source/clustering.Rmd
+++ b/source/clustering.Rmd
@@ -1161,16 +1161,19 @@ elbow_plot
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Clustering" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Clustering" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+
+
+
 
 ## Additional resources
 - Chapter 10 of *An Introduction to Statistical

--- a/source/inference.Rmd
+++ b/source/inference.Rmd
@@ -1170,16 +1170,15 @@ statistical techniques you may learn about in the future!
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the two "Statistical inference" rows.
-You can launch an interactive version of each worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of each worksheet by clicking "view worksheet."
-If you instead decide to download the worksheets and run them on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the two "Statistical inference" rows.  You can preview a
+non-interactive version of each worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
 
 ## Additional resources
 

--- a/source/intro.Rmd
+++ b/source/intro.Rmd
@@ -740,13 +740,14 @@ knitr::include_graphics("img/intro/help-filter.png")
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "R and the tidyverse" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "R and the tidyverse" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+

--- a/source/preface.Rmd
+++ b/source/preface.Rmd
@@ -42,14 +42,13 @@ knitr::include_graphics("img/frontmatter/chapter_overview.png")
 
 Each chapter in the book has an accompanying worksheet that provides exercises
 to help you practice the concepts you will learn. We strongly recommend that you
-work through the worksheet when you finish reading each chapter 
+work through the worksheet for each chapter 
 before moving on to the next chapter. All of the worksheets
 are available at 
 [https://worksheets.datasciencebook.ca](https://worksheets.datasciencebook.ca);
 the "Exercises" section at the end of each chapter points you to the right worksheet for that chapter.
-For each worksheet, you can either launch an interactive version of the worksheet in your browser by clicking the "launch binder" button,
-or preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
+For each worksheet, you can preview a non-interactive version of the worksheet by clicking "view worksheet."
+To work on the exercises interactively, follow the instructions in the worksheets repository
+to download all worksheets, and follow the instructions for computer setup
 found in Chapter \@ref(setup). This will ensure that the automated feedback
 and guidance that the worksheets provide will function as intended.

--- a/source/reading.Rmd
+++ b/source/reading.Rmd
@@ -1334,16 +1334,17 @@ data you are requesting and how frequently you are making requests.
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Reading in data locally and from the web" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Reading in data locally and from the web" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+
 
 ## Additional resources
 - The [`readr` documentation](https://readr.tidyverse.org/)

--- a/source/regression1.Rmd
+++ b/source/regression1.Rmd
@@ -887,15 +887,15 @@ regression has both strengths and weaknesses. Some are listed here:
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Regression I: K-nearest neighbors" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Regression I: K-nearest neighbors" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
 
 

--- a/source/regression2.Rmd
+++ b/source/regression2.Rmd
@@ -917,17 +917,15 @@ that will serve you well when moving to more advanced books on the topic.
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Regression II: linear regression" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
-
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Regression II: linear regression" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
 
 
 ## Additional resources

--- a/source/setup.Rmd
+++ b/source/setup.Rmd
@@ -40,11 +40,7 @@ By the end of the chapter, readers will be able to do the following:
 
 The worksheets containing exercises for this book
 are online at [https://worksheets.datasciencebook.ca](https://worksheets.datasciencebook.ca).
-The worksheets can be launched directly from that page using the Binder links in the rightmost
-column of the table. This is the easiest way to access the worksheets, but note that you will not
-be able to save your work and return to it again later.
-In order to save your progress, you will need to download the worksheets to your own computer and
-work on them locally. You can download the worksheets as a compressed zip file
+You can download the worksheets as a compressed zip file
 using [the link at the top of the page](https://github.com/UBC-DSCI/data-science-a-first-intro-worksheets/archive/refs/heads/main.zip).
 Once you unzip the downloaded file, you will have a folder containing all of the Jupyter notebook worksheets
 accompanying this book. See Chapter \@ref(jupyter) for

--- a/source/version-control.Rmd
+++ b/source/version-control.Rmd
@@ -925,16 +925,17 @@ image_read("img/version-control/issue_06.png") |>
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Collaboration with version control" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Collaboration with version control" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+
 
 ## Additional resources {#vc-add-res}
 

--- a/source/viz.Rmd
+++ b/source/viz.Rmd
@@ -1515,16 +1515,17 @@ knitr::include_graphics("img/viz/png-vs-svg.png")
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Effective data visualization" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Effective data visualization" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+
 
 ## Additional resources
 - The [`ggplot2` R package page](https://ggplot2.tidyverse.org) [@ggplot] is

--- a/source/wrangling.Rmd
+++ b/source/wrangling.Rmd
@@ -1571,16 +1571,17 @@ Table: (#tab:summary-functions-table) Summary of wrangling functions
 
 ## Exercises
 
-Practice exercises for the material covered in this chapter
-can be found in the accompanying
-[worksheets repository](https://worksheets.datasciencebook.ca)
-in the "Cleaning and wrangling data" row.
-You can launch an interactive version of the worksheet in your browser by clicking the "launch binder" button.
-You can also preview a non-interactive version of the worksheet by clicking "view worksheet."
-If you instead decide to download the worksheet and run it on your own machine,
-make sure to follow the instructions for computer setup
-found in Chapter \@ref(setup). This will ensure that the automated feedback
-and guidance that the worksheets provide will function as intended.
+Practice exercises for the material covered in this chapter can be found in the
+accompanying [worksheets repository](https://worksheets.datasciencebook.ca) in
+the "Cleaning and wrangling data" row.  You can preview a
+non-interactive version of the worksheet for this chapter by clicking "view
+worksheet." To work on the exercises interactively, follow the instructions in
+the worksheets repository to download all worksheets, and follow the
+instructions for computer setup found in Chapter \@ref(setup). This will ensure
+that the automated feedback and guidance that the worksheets provide will
+function as intended.
+
+
 
 
 


### PR DESCRIPTION
I'm about to remove binder links from the worksheets repositories (they no longer work -- binder's compute credits expired and they now just don't load, and the environment yaml has issues with consistency anyway). This update to the textbook removes the binder suggestion and just tells users to use the setup instructions in the textbook.

(will make a similar PR to python book shortly)