### PR TITLE
Remove word duplication of "precision" on classification2

### DIFF
--- a/source/classification2.Rmd
+++ b/source/classification2.Rmd
@@ -1233,7 +1233,9 @@ validation accuracy estimate varies only by around `r round(3*sd(100*accuracies$
 each estimate having a standard error around `r round(mean(100*accuracies$std_err), 0)`%.
 Since the cross-validation accuracy estimates the test set accuracy,
 the fact that the test set accuracy also doesn't change much is expected.
-Also note that the $K =$ 3 model had a precision of `r round(100*cancer_prec_1$.estimate, 0)`% and recall of `r round(100*cancer_rec_1$.estimate, 0)`%,
+Also note that the $K =$ 3 model had
+a precision of `r round(100*cancer_prec_1$.estimate, 0)`% and 
+recall of `r round(100*cancer_rec_1$.estimate, 0)`%,
 while the tuned model had
 a precision of `r round(100*cancer_prec_tuned, 0)`% and recall of `r round(100*cancer_rec_tuned, 0)`%.
 Given that the recall decreased&mdash;remember, in this application, recall

--- a/source/classification2.Rmd
+++ b/source/classification2.Rmd
@@ -1233,8 +1233,7 @@ validation accuracy estimate varies only by around `r round(3*sd(100*accuracies$
 each estimate having a standard error around `r round(mean(100*accuracies$std_err), 0)`%.
 Since the cross-validation accuracy estimates the test set accuracy,
 the fact that the test set accuracy also doesn't change much is expected.
-Also note that the $K =$ 3 model had a precision 
-precision of `r round(100*cancer_prec_1$.estimate, 0)`% and recall of `r round(100*cancer_rec_1$.estimate, 0)`%,
+Also note that the $K =$ 3 model had a precision of `r round(100*cancer_prec_1$.estimate, 0)`% and recall of `r round(100*cancer_rec_1$.estimate, 0)`%,
 while the tuned model had
 a precision of `r round(100*cancer_prec_tuned, 0)`% and recall of `r round(100*cancer_rec_tuned, 0)`%.
 Given that the recall decreased&mdash;remember, in this application, recall

--- a/source/classification2.Rmd
+++ b/source/classification2.Rmd
@@ -1234,7 +1234,7 @@ each estimate having a standard error around `r round(mean(100*accuracies$std_er
 Since the cross-validation accuracy estimates the test set accuracy,
 the fact that the test set accuracy also doesn't change much is expected.
 Also note that the $K =$ 3 model had
-a precision of `r round(100*cancer_prec_1$.estimate, 0)`% and 
+a precision of `r round(100*cancer_prec_1$.estimate, 0)`% and
 recall of `r round(100*cancer_rec_1$.estimate, 0)`%,
 while the tuned model had
 a precision of `r round(100*cancer_prec_tuned, 0)`% and recall of `r round(100*cancer_rec_tuned, 0)`%.


### PR DESCRIPTION
Hey there!

I was reading the Classification 2 chapter when I stumbled upon an accidental word duplication of "precision", within `6.6.4 Evaluating on the test set` of `classification2.Rmd`.

You can see the error below (bolded for clarity)
> Also note that the $K =$ 3 model had a **precision precision** of 77% and recall of 87%, while the tuned model had a precision of 80% and recall of 83%. 

I corrected the sentence by removing the second precision, and it now reads as follows:
> Also note that the $K =$ 3 model had a precision of 77% and recall of 87%, while the tuned model had a precision of 80% and recall of 83%. 

While a minor typo, it's still a readability error and may confuse the reader.


Thanks in advance,

A DSCI-100 student!
